### PR TITLE
Hide the overflow button if not needed

### DIFF
--- a/github-retro.user.css
+++ b/github-retro.user.css
@@ -40,6 +40,10 @@
 	.js-navigation-item:not(.js-issue-row) {
 		border-bottom: solid 1px rgba(0, 0, 0, 0.1);
 	}
+	/* Hides overflow button when not needed */
+	.js-responsive-underlinenav-overflow{
+	    display: none;
+	}
 }
 @-moz-document domain("github.com") {
 	/* Squarish avatars. */

--- a/github-retro.user.css
+++ b/github-retro.user.css
@@ -35,14 +35,14 @@
 		a.js-selected-navigation-item {
 			visibility: unset !important;
 		}
+		/* Hides overflow button when not needed */
+		.js-responsive-underlinenav-overflow{
+		    display: none;
+		}
 	}
 	/* Lines between files/folders. */
 	.js-navigation-item:not(.js-issue-row) {
 		border-bottom: solid 1px rgba(0, 0, 0, 0.1);
-	}
-	/* Hides overflow button when not needed */
-	.js-responsive-underlinenav-overflow{
-	    display: none;
 	}
 }
 @-moz-document domain("github.com") {


### PR DESCRIPTION
When the window was over a certain width (around 1864px) the overflow
button was shown even though it is not needed.

![image](https://user-images.githubusercontent.com/49487896/85752936-5a860300-b6fb-11ea-9812-4938ab1b3c6b.png)
