### PR TITLE
Tweak status badge location/shape

### DIFF
--- a/github-retro.user.css
+++ b/github-retro.user.css
@@ -50,4 +50,20 @@
 	.avatar-user {
 		border-radius: 10% !important;
 	}
+	
+	.user-status-circle-badge {
+	    width: 60px;
+	    box-shadow: none;
+	    border: none;
+	}
+
+	.user-status-circle-badge:hover {
+	    width: unset;
+	    box-shadow: none;
+	    border: none;
+	}
+
+	.user-status-circle-badge-container {
+	    left: 102%;
+	}
 }

--- a/github-retro.user.css
+++ b/github-retro.user.css
@@ -57,10 +57,18 @@
 	    border: none;
 	}
 
+	.user-status-circle-badge-container {
+	    width: 60px;
+	}
+
 	.user-status-circle-badge:hover {
 	    width: unset;
 	    box-shadow: none;
 	    border: none;
+	}
+
+	.user-status-circle-badge-container:hover {
+	    width: unset;
 	}
 
 	.user-status-circle-badge-container {


### PR DESCRIPTION
Hello! I'm really liking this stylesheet, it's very nice.

I'm interested in what you think of the change that I've added.

It changes the position and shaping of the status badge on a user's profile page. The difference is shown below.


| Standard | This PR |
| ------------- | ------------- |
| ![firefox_2020-06-29_00-03-26](https://user-images.githubusercontent.com/25284325/85960567-53315480-b99c-11ea-8cb4-184ab5db1601.png) | ![firefox_2020-06-29_00-03-12](https://user-images.githubusercontent.com/25284325/85960572-5f1d1680-b99c-11ea-8d8a-79e70c6d1a4a.png) |

The only small thing with this is that there's no border on the badge. It would show up the full shape and look strange. like this:
![firefox_2020-06-29_00-08-19](https://user-images.githubusercontent.com/25284325/85960611-b4f1be80-b99c-11ea-9bcd-5b4e128ed072.png)

