### PR TITLE
No longer sets a property on every site

### DIFF
--- a/github-retro.user.css
+++ b/github-retro.user.css
@@ -10,10 +10,12 @@
 @license      CC-BY-SA-4.0
 @preprocessor uso
 ==/UserStyle== */
-:root {
-	--line-color: rgba(0, 0, 0, 0.1);
-}
+
 @-moz-document regexp("^https?:\\/\\/github.com.*") {
+	:root {
+		--line-color: rgba(0, 0, 0, 0.1);
+	}
+
 	@media (min-width: 1280px) {
 		main > div > div.d-flex,
 		nav.UnderlineNav {


### PR DESCRIPTION
The `:root` rule was placed outside of the domain matching causing it to work on every site.